### PR TITLE
feat: define common classes to implement Schema Registry resource plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,13 @@
             <version>${gravitee-resource-api.version}</version>
             <scope>provided</scope>
         </dependency>
+
+        <!-- Other -->
+        <dependency>
+            <groupId>io.reactivex.rxjava3</groupId>
+            <artifactId>rxjava</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/io/gravitee/resource/schema_registry/api/Schema.java
+++ b/src/main/java/io/gravitee/resource/schema_registry/api/Schema.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.schema_registry.api;
+
+public interface Schema {
+    String getContent();
+    String getId();
+    String getSubject();
+    String getVersion();
+}

--- a/src/main/java/io/gravitee/resource/schema_registry/api/SchemaLoadException.java
+++ b/src/main/java/io/gravitee/resource/schema_registry/api/SchemaLoadException.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.schema_registry.api;
+
+public class SchemaLoadException extends RuntimeException {
+
+    public SchemaLoadException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/io/gravitee/resource/schema_registry/api/SchemaRegistryResource.java
+++ b/src/main/java/io/gravitee/resource/schema_registry/api/SchemaRegistryResource.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.schema_registry.api;
+
+import io.gravitee.resource.api.AbstractConfigurableResource;
+import io.gravitee.resource.api.ResourceConfiguration;
+import io.reactivex.rxjava3.core.Maybe;
+
+public abstract class SchemaRegistryResource<C extends ResourceConfiguration> extends AbstractConfigurableResource<C> {
+
+    public abstract Maybe<Schema> getSchema(String subject);
+
+    public abstract Maybe<Schema> getSchema(String subject, String version);
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-688

**Description**

Define common classes to implement Schema Registry resource plugin.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-apim688-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-schema-registry-provider-api/1.0.0-apim688-SNAPSHOT/gravitee-resource-schema-registry-provider-api-1.0.0-apim688-SNAPSHOT.zip)
  <!-- Version placeholder end -->
