### PR TITLE
feat: add method to fetch schema by-passing the cache

### DIFF
--- a/src/main/java/io/gravitee/resource/schema_registry/api/SchemaRegistryResource.java
+++ b/src/main/java/io/gravitee/resource/schema_registry/api/SchemaRegistryResource.java
@@ -21,7 +21,35 @@ import io.reactivex.rxjava3.core.Maybe;
 
 public abstract class SchemaRegistryResource<C extends ResourceConfiguration> extends AbstractConfigurableResource<C> {
 
+    /**
+     * Fetch the latest version of a schema from the schema registry.
+     * @param subject The subject used to fetch the schema.
+     * @return Maybe of Schema
+     */
     public abstract Maybe<Schema> getSchema(String subject);
 
+    /**
+     * Fetch the latest version of a schema from the schema registry.
+     * @param subject The subject used to fetch the schema.
+     * @param ignoreCache A flag to ignore the potential cache.
+     * @return Maybe of Schema
+     */
+    public abstract Maybe<Schema> getSchema(String subject, boolean ignoreCache);
+
+    /**
+     * Fetch a version of a schema from the schema registry.
+     * @param subject The subject used to fetch the schema.
+     * @param version The wanted version.
+     * @return Maybe of Schema
+     */
     public abstract Maybe<Schema> getSchema(String subject, String version);
+
+    /**
+     * Fetch a version of a schema from the schema registry.
+     * @param subject The subject used to fetch the schema
+     * @param version The wanted version.
+     * @param ignoreCache A flag to ignore the potential cache.
+     * @return Maybe of Schema
+     */
+    public abstract Maybe<Schema> getSchema(String subject, String version, boolean ignoreCache);
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-802

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-apim802-add-cache-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-schema-registry-provider-api/1.0.0-apim802-add-cache-SNAPSHOT/gravitee-resource-schema-registry-provider-api-1.0.0-apim802-add-cache-SNAPSHOT.zip)
  <!-- Version placeholder end -->
