### PR TITLE
feat: add method to fetch a schema by id

### DIFF
--- a/src/main/java/io/gravitee/resource/schema_registry/api/SchemaRegistryResource.java
+++ b/src/main/java/io/gravitee/resource/schema_registry/api/SchemaRegistryResource.java
@@ -22,6 +22,13 @@ import io.reactivex.rxjava3.core.Maybe;
 public abstract class SchemaRegistryResource<C extends ResourceConfiguration> extends AbstractConfigurableResource<C> {
 
     /**
+     * Fetch a schema from the schema registry using its id.
+     * @param id The id used to fetch the schema.
+     * @return Maybe of Schema
+     */
+    public abstract Maybe<Schema> getSchemaById(String id);
+
+    /**
      * Fetch the latest version of a schema from the schema registry.
      * @param subject The subject used to fetch the schema.
      * @return Maybe of Schema


### PR DESCRIPTION
**Description**

Add method to fetch a schema by id

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-get-schema-by-id-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-schema-registry-provider-api/1.0.0-get-schema-by-id-SNAPSHOT/gravitee-resource-schema-registry-provider-api-1.0.0-get-schema-by-id-SNAPSHOT.zip)
  <!-- Version placeholder end -->
