### PR TITLE
ci: use the correct workflow for libs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ workflows:
         when:
             not: << pipeline.git.tag >>
         jobs:
-            - gravitee/setup_plugin-build-config:
+            - gravitee/setup_lib-build-config:
                   filters:
                       tags:
                           ignore:
@@ -25,7 +25,7 @@ workflows:
                 pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
                 value: << pipeline.git.tag >>
         jobs:
-            - gravitee/setup_plugin-release-config:
+            - gravitee/setup_lib-release-config:
                   filters:
                       branches:
                           ignore:


### PR DESCRIPTION
**Description**

The workflow was incorrect and it was trying to publish the lib in downloads.gravitee.io 🙈 
**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-schema-registry-provider-api/1.0.0/gravitee-resource-schema-registry-provider-api-1.0.0.zip)
  <!-- Version placeholder end -->
