### PR TITLE
fix: add support for fetching schema references

### DIFF
--- a/src/main/java/io/gravitee/resource/schema_registry/api/Reference.java
+++ b/src/main/java/io/gravitee/resource/schema_registry/api/Reference.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.schema_registry.api;
+
+public class Reference {
+
+    String name;
+    String subject;
+    int version;
+
+    public Reference() {}
+
+    public Reference(String name, String subject, int version) {
+        this.name = name;
+        this.subject = subject;
+        this.version = version;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+}

--- a/src/main/java/io/gravitee/resource/schema_registry/api/Schema.java
+++ b/src/main/java/io/gravitee/resource/schema_registry/api/Schema.java
@@ -15,9 +15,14 @@
  */
 package io.gravitee.resource.schema_registry.api;
 
+import java.util.List;
+import java.util.Map;
+
 public interface Schema {
     String getContent();
     String getId();
     String getSubject();
     String getVersion();
+    List<Reference> getReferences();
+    Map<String, String> getDependencies();
 }


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/GKO-1385

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.1-gko-protobuf-json-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-schema-registry-provider-api/1.0.1-gko-protobuf-json-SNAPSHOT/gravitee-resource-schema-registry-provider-api-1.0.1-gko-protobuf-json-SNAPSHOT.zip)
  <!-- Version placeholder end -->
