### PR TITLE
feat: expose schema type and subject-membership lookup on the SPI

### DIFF
--- a/src/main/java/io/gravitee/resource/schema_registry/api/SchemaRegistryResource.java
+++ b/src/main/java/io/gravitee/resource/schema_registry/api/SchemaRegistryResource.java
@@ -18,6 +18,8 @@ package io.gravitee.resource.schema_registry.api;
 import io.gravitee.resource.api.AbstractConfigurableResource;
 import io.gravitee.resource.api.ResourceConfiguration;
 import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import java.util.List;
 
 public abstract class SchemaRegistryResource<C extends ResourceConfiguration> extends AbstractConfigurableResource<C> {
 
@@ -59,4 +61,34 @@ public abstract class SchemaRegistryResource<C extends ResourceConfiguration> ex
      * @return Maybe of Schema
      */
     public abstract Maybe<Schema> getSchema(String subject, String version, boolean ignoreCache);
+
+    /**
+     * Check whether the given schema content is registered under the subject, independently of which
+     * version is {@code latest}. When it is, resolves to the registered {@link Schema} carrying its id,
+     * version and type; otherwise resolves empty.
+     * <p>
+     * The default implementation resolves empty so registries that do not support membership lookups
+     * degrade gracefully: callers treat "no membership info" as "not a member" and may fall back to
+     * their current {@code latest} comparison.
+     *
+     * @param subject the subject the schema is expected to be registered under.
+     * @param schemaContent the raw schema definition to look up.
+     * @return Maybe of the registered Schema, or empty if not registered / unsupported.
+     */
+    public Maybe<Schema> lookupUnderSubject(String subject, String schemaContent) {
+        return Maybe.empty();
+    }
+
+    /**
+     * List the version identifiers registered under the subject. Convenience for diagnostics/UX; the
+     * membership primitive ({@link #lookupUnderSubject}) is what the gate needs.
+     * <p>
+     * The default implementation resolves an empty list for registries that do not support it.
+     *
+     * @param subject the subject to list versions for.
+     * @return Single of the registered version identifiers (possibly empty).
+     */
+    public Single<List<String>> getVersions(String subject) {
+        return Single.just(List.of());
+    }
 }

--- a/src/main/java/io/gravitee/resource/schema_registry/api/SchemaType.java
+++ b/src/main/java/io/gravitee/resource/schema_registry/api/SchemaType.java
@@ -15,23 +15,13 @@
  */
 package io.gravitee.resource.schema_registry.api;
 
-import java.util.List;
-import java.util.Map;
-
-public interface Schema {
-    String getContent();
-    String getId();
-    String getSubject();
-    String getVersion();
-    List<Reference> getReferences();
-    Map<String, String> getDependencies();
-
-    /**
-     * Serialization format of this schema (AVRO/JSON/PROTOBUF) as reported by the registry.
-     * Defaults to {@link SchemaType#UNKNOWN} for implementations that do not expose a type,
-     * keeping existing implementations source- and binary-compatible.
-     */
-    default SchemaType getType() {
-        return SchemaType.UNKNOWN;
-    }
+/**
+ * Serialization format of a {@link Schema}, as reported by the registry.
+ * {@code UNKNOWN} is the default for registries (or schemas) that do not expose a type.
+ */
+public enum SchemaType {
+    AVRO,
+    JSON,
+    PROTOBUF,
+    UNKNOWN,
 }


### PR DESCRIPTION
## What

Evolves the schema-registry SPI into a richer, registry-agnostic contract so schema-aware policies (Data Contract, Transform Avro/JSON/Protobuf) can detect a payload's format and check version-set membership without per-registry special-casing.

All additions are **`default` methods** — existing implementations compile and run unchanged. SemVer: **1.0.1 → 1.1.0** (minor).

### Added

- **`SchemaType`** enum (`AVRO`, `JSON`, `PROTOBUF`, `UNKNOWN`).
- **`Schema.getType()`** — `default` returning `SchemaType.UNKNOWN`.
- **`SchemaRegistryResource.lookupUnderSubject(subject, schemaContent)`** — `default` returning `Maybe.empty()`. Resolves to the registered `Schema` (id + version) when the content is registered under the subject, independently of `latest`; non-supporting registries degrade gracefully (caller treats "no membership info" as "not a member").
- **`SchemaRegistryResource.getVersions(subject)`** — `default` returning an empty list. Diagnostics/UX convenience.

### Backward compatibility

Verified the `gravitee-resource-schema-registry-embedded` resource compiles against 1.1.0 with **no source changes**.

### Follow-up

The Confluent implementation (`gravitee-resource-schema-registry-confluent`) populates these from REST responses and fixes a numeric-`id` deserialization bug — separate PR, depends on this 1.1.0 release.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.0-feat-schema-type-and-subject-membership-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-schema-registry-provider-api/1.1.0-feat-schema-type-and-subject-membership-SNAPSHOT/gravitee-resource-schema-registry-provider-api-1.1.0-feat-schema-type-and-subject-membership-SNAPSHOT.zip)
  <!-- Version placeholder end -->
